### PR TITLE
Added python interface for multiple start indices

### DIFF
--- a/bench/test_bench.py
+++ b/bench/test_bench.py
@@ -32,6 +32,12 @@ def test_vanilla_fps_4k(benchmark):
     pc = create_sample_data(n_points, n_dim)
     benchmark(fpsample.fps_sampling, pc, n_samples)
 
+@pytest.mark.benchmark(**TEST_BENCHMARK_SETTINGS["4k"])
+def test_vanilla_fps_4k(benchmark):
+    n_points, n_samples, n_dim = TEST_CASE_SETTINGS["4k"]
+    pc = create_sample_data(n_points, n_dim)
+    benchmark(fpsample.fps_sampling, pc, n_samples, start_idx=[0, 23, 64, 128])
+
 
 @pytest.mark.benchmark(**TEST_BENCHMARK_SETTINGS["4k"])
 def test_fps_npdu_4k(benchmark):

--- a/bench/test_bench.py
+++ b/bench/test_bench.py
@@ -33,7 +33,7 @@ def test_vanilla_fps_4k(benchmark):
     benchmark(fpsample.fps_sampling, pc, n_samples)
 
 @pytest.mark.benchmark(**TEST_BENCHMARK_SETTINGS["4k"])
-def test_vanilla_fps_4k(benchmark):
+def test_vanilla_fps_4k_multiple(benchmark):
     n_points, n_samples, n_dim = TEST_CASE_SETTINGS["4k"]
     pc = create_sample_data(n_points, n_dim)
     benchmark(fpsample.fps_sampling, pc, n_samples, start_idx=[0, 23, 64, 128])

--- a/python/fpsample/wrapper.py
+++ b/python/fpsample/wrapper.py
@@ -28,11 +28,14 @@ def fps_sampling(pc: np.ndarray, n_samples: int, start_idx: Optional[Union[int, 
     assert pc.ndim == 2
     n_pts, _ = pc.shape
     assert n_pts >= n_samples, "n_pts should be >= n_samples"
-    assert (
-            start_idx is None or 0 <= start_idx < n_pts
-    ), "start_idx should be None or 0 <= start_idx < n_pts"
+    if isinstance(start_idx, int):
+        assert (
+                start_idx is None or 0 <= start_idx < n_pts
+        ), "start_idx should be None or 0 <= start_idx < n_pts"
     if isinstance(start_idx, list):
         assert len(start_idx) <= n_samples, "len(start_idx) should be <= n_samples"
+        for idx in start_idx:
+            assert 0 <= idx < n_pts, "start_idx should be None or 0 <= start_idx < n_pts"
     # best performance with fortran array
     pc = np.asfortranarray(pc, dtype=np.float32)
     # Random pick a start if not given

--- a/python/fpsample/wrapper.py
+++ b/python/fpsample/wrapper.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional
+from typing import Optional, Union, List
 
 import numpy as np
 
@@ -12,14 +12,15 @@ from .fpsample import (
 )
 
 
-def fps_sampling(pc: np.ndarray, n_samples: int, start_idx: Optional[int] = None) -> np.ndarray:
+def fps_sampling(pc: np.ndarray, n_samples: int, start_idx: Optional[Union[int, List[int]]] = None) -> np.ndarray:
     """
     Vanilla FPS sampling.
 
     Args:
         pc (np.ndarray): The input point cloud of shape (n_pts, D).
         n_samples (int): Number of samples.
-        start_idx (int, default=None): The starting index of sampling. If set to None, it will be randomly picked.
+        start_idx (int or list[int], default=None): The starting index of sampling. If set to None, it will be randomly picked.
+            If multiple start indices are given, they are used as a start set for the FPS and will all be present in the final samples.
     Returns:
         np.ndarray: The selected indices of shape (n_samples,).
     """
@@ -28,17 +29,19 @@ def fps_sampling(pc: np.ndarray, n_samples: int, start_idx: Optional[int] = None
     n_pts, _ = pc.shape
     assert n_pts >= n_samples, "n_pts should be >= n_samples"
     assert (
-        start_idx is None or 0 <= start_idx < n_pts
+            start_idx is None or 0 <= start_idx < n_pts
     ), "start_idx should be None or 0 <= start_idx < n_pts"
+    if isinstance(start_idx, list):
+        assert len(start_idx) <= n_samples, "len(start_idx) should be <= n_samples"
     # best performance with fortran array
     pc = np.asfortranarray(pc, dtype=np.float32)
-    # Random pick a start
-    start_idx = np.random.randint(low=0, high=n_pts) if start_idx is None else start_idx
+    # Random pick a start if not given
+    start_idx = get_start_idx(n_pts, start_idx)
     return _fps_sampling(pc, n_samples, start_idx)
 
 
 def fps_npdu_sampling(
-    pc: np.ndarray, n_samples: int, w: Optional[int] = None, start_idx: Optional[int] = None
+        pc: np.ndarray, n_samples: int, w: Optional[int] = None, start_idx: Optional[Union[int, List[int]]] = None
 ) -> np.ndarray:
     """
     FPS sampling with nearest-point-distance-updating (NPDU) heuristic strategy.
@@ -48,7 +51,8 @@ def fps_npdu_sampling(
         pc (np.ndarray): The input point cloud of shape (n_pts, D).
         n_samples (int): Number of samples.
         w (int, default=None): Windows size of local heuristic search. If set to None, it will be set to `n_pts / n_samples * 16`.
-        start_idx (int, default=None): The starting index of sampling. If set to None, it will be randomly picked.
+        start_idx (int or list[int], default=None): The starting index of sampling. If set to None, it will be randomly picked.
+            If multiple start indices are given, they are used as a start set for the FPS and will all be present in the final samples.
     Returns:
         np.ndarray: The selected indices of shape (n_samples,).
     """
@@ -57,20 +61,22 @@ def fps_npdu_sampling(
     n_pts, _ = pc.shape
     assert n_pts >= n_samples, "n_pts should be >= n_samples"
     assert (
-        start_idx is None or 0 <= start_idx < n_pts
+            start_idx is None or 0 <= start_idx < n_pts
     ), "start_idx should be None or 0 <= start_idx < n_pts"
+    if isinstance(start_idx, list):
+        assert len(start_idx) <= n_samples, "len(start_idx) should be <= n_samples"
     pc = np.ascontiguousarray(pc, dtype=np.float32)
     w = w or int(n_pts / n_samples * 16)
     if w >= n_pts - 1:
         warnings.warn(f"k is too large, set to {n_pts - 1}")
         w = n_pts - 1
-    # Random pick a start
-    start_idx = np.random.randint(low=0, high=n_pts) if start_idx is None else start_idx
+    # Random pick a start if not given
+    start_idx = get_start_idx(n_pts, start_idx)
     return _fps_npdu_sampling(pc, n_samples, w, start_idx)
 
 
 def fps_npdu_kdtree_sampling(
-    pc: np.ndarray, n_samples: int, w: Optional[int] = None, start_idx: Optional[int] = None
+        pc: np.ndarray, n_samples: int, w: Optional[int] = None, start_idx: Optional[Union[int, List[int]]] = None
 ) -> np.ndarray:
     """
     FPS sampling with nearest-point-distance-updating (NPDU) heuristic strategy.
@@ -81,7 +87,8 @@ def fps_npdu_kdtree_sampling(
         pc (np.ndarray): The input point cloud of shape (n_pts, D).
         n_samples (int): Number of samples.
         w (int, default=None): Windows size of local heuristic search. If set to None, it will be set to `n_pts / n_samples * 16`.
-        start_idx (int, default=None): The starting index of sampling. If set to None, it will be randomly picked.
+        start_idx (int or list[int], default=None): The starting index of sampling. If set to None, it will be randomly picked.
+            If multiple start indices are given, they are used as a start set for the FPS and will all be present in the final samples.
     Returns:
         np.ndarray: The selected indices of shape (n_samples,).
     """
@@ -90,20 +97,22 @@ def fps_npdu_kdtree_sampling(
     n_pts, _ = pc.shape
     assert n_pts >= n_samples, "n_pts should be >= n_samples"
     assert (
-        start_idx is None or 0 <= start_idx < n_pts
+            start_idx is None or 0 <= start_idx < n_pts
     ), "start_idx should be None or 0 <= start_idx < n_pts"
+    if isinstance(start_idx, list):
+        assert len(start_idx) <= n_samples, "len(start_idx) should be <= n_samples"
     pc = np.ascontiguousarray(pc, dtype=np.float32)
     w = w or int(n_pts / n_samples * 16)
     if w >= n_pts:
         warnings.warn(f"k is too large, set to {n_pts}")
         w = n_pts
-    # Random pick a start
-    start_idx = np.random.randint(low=0, high=n_pts) if start_idx is None else start_idx
+    # Random pick a start if not given
+    start_idx = get_start_idx(n_pts, start_idx)
     return _fps_npdu_kdtree_sampling(pc, n_samples, w, start_idx)
 
 
 def bucket_fps_kdtree_sampling(
-    pc: np.ndarray, n_samples: int, start_idx: Optional[int] = None
+        pc: np.ndarray, n_samples: int, start_idx: Optional[Union[int, List[int]]] = None
 ) -> np.ndarray:
     """
     Bucket-based FPS sampling using KDTree. Also called "QuickFPS" in the paper.
@@ -111,7 +120,8 @@ def bucket_fps_kdtree_sampling(
     Args:
         pc (np.ndarray): The input point cloud of shape (n_pts, D).
         n_samples (int): Number of samples.
-        start_idx (int, default=None): The starting index of sampling. If set to None, it will be randomly picked.
+        start_idx (int or list[int], default=None): The starting index of sampling. If set to None, it will be randomly picked.
+            If multiple start indices are given, they are used as a start set for the FPS and will all be present in the final samples.
     Returns:
         np.ndarray: The selected indices of shape (n_samples,).
     """
@@ -120,16 +130,18 @@ def bucket_fps_kdtree_sampling(
     n_pts, _ = pc.shape
     assert n_pts >= n_samples, "n_pts should be >= n_samples"
     assert (
-        start_idx is None or 0 <= start_idx < n_pts
+            start_idx is None or 0 <= start_idx < n_pts
     ), "start_idx should be None or 0 <= start_idx < n_pts"
+    if isinstance(start_idx, list):
+        assert len(start_idx) <= n_samples, "len(start_idx) should be <= n_samples"
     pc = np.ascontiguousarray(pc, dtype=np.float32)
-    # Random pick a start
-    start_idx = np.random.randint(low=0, high=n_pts) if start_idx is None else start_idx
+    # Random pick a start if not given
+    start_idx = get_start_idx(n_pts, start_idx)
     return _bucket_fps_kdtree_sampling(pc, n_samples, start_idx)
 
 
 def bucket_fps_kdline_sampling(
-    pc: np.ndarray, n_samples: int, h: int, start_idx: Optional[int] = None
+        pc: np.ndarray, n_samples: int, h: int, start_idx: Optional[Union[int, List[int]]] = None
 ) -> np.ndarray:
     """
     Bucket-based FPS sampling using KDTree, with multiple points in each bucket. Also called "QuickFPS" in the paper.
@@ -140,7 +152,8 @@ def bucket_fps_kdline_sampling(
         h (int, default=None): Height of KDTree. The bucket size is `2**h`.
             According to the paper, for small workload, h=3 is enough;
             for medium workload, h=5 or 7 is enough; for large workload, h=9 is enough.
-        start_idx (int, default=None): The starting index of sampling. If set to None, it will be randomly picked.
+        start_idx (int or list[int], default=None): The starting index of sampling. If set to None, it will be randomly picked.
+            If multiple start indices are given, they are used as a start set for the FPS and will all be present in the final samples.
 
     Returns:
         np.ndarray: The selected indices of shape (n_samples,).
@@ -150,11 +163,29 @@ def bucket_fps_kdline_sampling(
     n_pts, _ = pc.shape
     assert n_pts >= n_samples, "n_pts should be >= n_samples"
     assert h >= 1, "h should be >= 1"
-    assert 2**h <= n_pts, "2**h should be <= n_pts"
+    assert 2 ** h <= n_pts, "2**h should be <= n_pts"
     assert (
-        start_idx is None or 0 <= start_idx < n_pts
+            start_idx is None or 0 <= start_idx < n_pts
     ), "start_idx should be None or 0 <= start_idx < n_pts"
+    if isinstance(start_idx, list):
+        assert len(start_idx) <= n_samples, "len(start_idx) should be <= n_samples"
     pc = np.ascontiguousarray(pc, dtype=np.float32)
-    # Random pick a start
-    start_idx = np.random.randint(low=0, high=n_pts) if start_idx is None else start_idx
+    # Random pick a start if not given
+    start_idx = get_start_idx(n_pts, start_idx)
     return _bucket_fps_kdline_sampling(pc, n_samples, h, start_idx)
+
+
+def get_start_idx(n_pts: int, start_idx: Optional[Union[int, List[int]]]) -> Union[int, np.ndarray]:
+    # Random pick a start or use the given start indices
+    if start_idx is None:
+        start_idx = np.random.randint(low=0, high=n_pts)
+    elif isinstance(start_idx, int):
+        # just use the int start_idx
+        start_idx = start_idx
+    elif isinstance(start_idx, list):
+        # convert to numpy array for rust
+        # TODO: maybe better performance with fortran array?
+        start_idx = np.array(start_idx, dtype=np.uint64)
+    else:
+        raise ValueError("start_idx should be None, int or list")
+    return start_idx


### PR DESCRIPTION
- Correct typing
- assert statement to check that start list <= num_samples
- conversion to unsigned int np array

Added rust wrappers to handle multiple start indices
- New start_idx enum to handle both cases
- Added Rust input check
- Rust interface setup for implementing multi start index algorithms.