### PR TITLE
Fix: Define ssize_t when using the Microsoft Visual Studio compiler.

### DIFF
--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -3,6 +3,11 @@
 #include "nanoflann.hpp"
 #include "wrapper.hpp"
 
+#if defined(_MSC_VER)
+    #include <BaseTsd.h>
+    typedef SSIZE_T ssize_t;
+#endif
+
 #define STRINGIFY(x) #x
 #define MACRO_STRINGIFY(x) STRINGIFY(x)
 


### PR DESCRIPTION
Hi there,

I just noticed that the package cannot be installed on my Windows machines. It seems to me that the ssize_t type is not defined when using the Microsoft Visual Studio compiler for C++, as ssize_t is a POSIX type and no part of C/C++.

This can be solved by including a library and defining the type according to the following thread: https://stackoverflow.com/questions/22265610/why-ssize-t-in-visual-studio-2010-is-defined-as-unsigned

I just forked and added these few lines that worked for me, in case you would like to add it :)  